### PR TITLE
PO image gallery expanded view and misc items

### DIFF
--- a/client/dist/style.css
+++ b/client/dist/style.css
@@ -305,7 +305,10 @@ li {
   left: 0;
   margin: 0;
   cursor: zoom-in;
+}
 
+.expanded-slide {
+  cursor: crosshair;
 }
 
 .carousel__track {

--- a/client/dist/style.css
+++ b/client/dist/style.css
@@ -321,6 +321,10 @@ li {
   background: transparent;
   border: 0;
   cursor: pointer;
+  border-radius: 50%;
+  height: 30px;
+  width: 30px;
+  background-color: rgba(255,255,255,0.5);
 }
 
 .carousel__button--left {
@@ -339,6 +343,10 @@ li {
   background: transparent;
   border: 0;
   cursor: pointer;
+  border-radius: 10%;
+  height: 30px;
+  width: 30px;
+  background-color: rgba(255,255,255,0.5);
 }
 
 .fa-arrow-right .fa-arrow-left {

--- a/client/dist/style.css
+++ b/client/dist/style.css
@@ -277,6 +277,10 @@ li {
 .style-element .style-img { display: block; }
 .style-element .selected { position: absolute; top:0; right:0; } */
 
+.po-image-gallery {
+  background: white;
+}
+
 .carousel {
   position: relative;
   height: 500px;

--- a/client/dist/style.css
+++ b/client/dist/style.css
@@ -321,13 +321,19 @@ li {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  background: transparent;
   border: 0;
   cursor: pointer;
   border-radius: 50%;
   height: 30px;
   width: 30px;
-  background-color: rgba(255,255,255,0.5);
+  background-color: rgba(0, 0, 0, 0.7);
+  opacity: 0.6;
+  transition: 0.3s;
+  color: #fff;
+}
+
+.carousel__button:hover {
+  opacity: 1;
 }
 
 .carousel__button--left {
@@ -340,25 +346,11 @@ li {
 }
 
 .carousel__button--expand {
-  position: absolute;
   top: 5%;
   right: 5%;
-  background: transparent;
-  border: 0;
-  cursor: pointer;
   border-radius: 10%;
-  height: 30px;
-  width: 30px;
-  background-color: rgba(255,255,255,0.5);
 }
 
-.fa-arrow-right .fa-arrow-left {
-  transition: all .2s ease-in-out;
-}
-
-.fa-arrow-right:hover .fa-arrow-left:hover {
-  transform: scale(1.1);
-}
 
 
 

--- a/client/dist/style.css
+++ b/client/dist/style.css
@@ -269,9 +269,21 @@ li {
   margin: 0 10px;
 }
 
-.selected {
-  border: solid red;
+.style-element {
+  width: 70px;
+  height: 74px;
 }
+
+.selected {
+  position: relative;
+  right: -65%;
+  top: -65px;
+  background: white;
+  border-radius: 50%;
+  border-width: 0;
+}
+
+
 
 /* .style-element { position: relative; }
 .style-element .style-img { display: block; }

--- a/client/dist/style.css
+++ b/client/dist/style.css
@@ -183,16 +183,21 @@ h3 {
 /*========= ======================== ===========*/
 
 .po-main-top {
+  position: relative;
   display: flex;
   height: 80%;
 }
 
 .po-main-left {
   width: 60%;
+  z-index: 20;
 }
 
 .po-main-right {
   width: 40%;
+  position: absolute;
+  top: 0;
+  right: 0;
 }
 
 .style-img {

--- a/client/src/Components/ProductOverview/POComponents/ImageGallery.jsx
+++ b/client/src/Components/ProductOverview/POComponents/ImageGallery.jsx
@@ -6,7 +6,8 @@ class ImageGallery extends React.Component {
     this.state = {
       photos: {},
       current: 0,
-      expanded: false
+      expanded: false,
+      zoomed: false
     };
     this.nextSlide = this.nextSlide.bind(this);
     this.prevSlide = this.prevSlide.bind(this);
@@ -71,7 +72,7 @@ class ImageGallery extends React.Component {
               <ul className='carousel__track'>
                 {fullPhotos.map((image, index) => {
                   return (
-                    <li key={index} className={index === this.state.current ? 'carousel__slide current_slide' : 'carousel__slide'} onClick={this.expandSlide}>
+                    <li key={index} className={this.state.expanded ? 'carousel__slide expanded-slide' : 'carousel__slide'} onClick={this.expandSlide}>
                       {index === this.state.current && (<img className='carousel__image' src={image} />)}
                     </li>
                   );

--- a/client/src/Components/ProductOverview/POComponents/ImageGallery.jsx
+++ b/client/src/Components/ProductOverview/POComponents/ImageGallery.jsx
@@ -78,10 +78,9 @@ class ImageGallery extends React.Component {
                 })}
               </ul>
             </div>
-            {!this.state.expanded && (<button className='carousel__button--expand' onClick={this.expandSlide} >
+            <button className='carousel__button--expand' onClick={this.expandSlide} >
               <i className="fas fa-expand fa-lg"></i>
-            </button>)}
-
+            </button>
             {this.state.current !== length - 1 && (<button className='carousel__button carousel__button--right' onClick={this.nextSlide} >
               <i className="fas fa-arrow-right fa-lg"></i>
             </button>)}

--- a/client/src/Components/ProductOverview/POComponents/ImageGallery.jsx
+++ b/client/src/Components/ProductOverview/POComponents/ImageGallery.jsx
@@ -90,7 +90,7 @@ class ImageGallery extends React.Component {
                 })}
               </ul>
             </div>
-            <button className='carousel__button--expand' onClick={this.expandSlide} >
+            <button className='carousel__button carousel__button--expand' onClick={this.expandSlide} >
               <i className="fas fa-expand fa-lg"></i>
             </button>
             {this.state.current !== length - 1 && (<button className='carousel__button carousel__button--right' onClick={this.nextSlide} >

--- a/client/src/Components/ProductOverview/POComponents/ImageGallery.jsx
+++ b/client/src/Components/ProductOverview/POComponents/ImageGallery.jsx
@@ -12,6 +12,7 @@ class ImageGallery extends React.Component {
     this.nextSlide = this.nextSlide.bind(this);
     this.prevSlide = this.prevSlide.bind(this);
     this.expandSlide = this.expandSlide.bind(this);
+    this.zoomSlide = this.zoomSlide.bind(this);
   }
 
   nextSlide() {
@@ -29,11 +30,21 @@ class ImageGallery extends React.Component {
   }
 
   expandSlide() {
+    if (this.state.expanded && this.state.zoomed) {
+      this.setState({zoomed: false});
+    }
     console.log('you want to expand the image');
     this.setState({
       expanded: !this.state.expanded
     });
     this.props.expandSlide();
+  }
+
+  zoomSlide() {
+    console.log('you want to zoom');
+    this.setState({
+      zoomed: !this.state.zoomed
+    });
   }
 
   componentDidUpdate(prevProps) {
@@ -72,7 +83,7 @@ class ImageGallery extends React.Component {
               <ul className='carousel__track'>
                 {fullPhotos.map((image, index) => {
                   return (
-                    <li key={index} className={this.state.expanded ? 'carousel__slide expanded-slide' : 'carousel__slide'} onClick={this.expandSlide}>
+                    <li key={index} className={this.state.expanded ? 'carousel__slide expanded-slide' : 'carousel__slide'} onClick={!this.state.expanded ? this.expandSlide : this.zoomSlide}>
                       {index === this.state.current && (<img className='carousel__image' src={image} />)}
                     </li>
                   );

--- a/client/src/Components/ProductOverview/POComponents/ImageGallery.jsx
+++ b/client/src/Components/ProductOverview/POComponents/ImageGallery.jsx
@@ -41,7 +41,7 @@ class ImageGallery extends React.Component {
   }
 
   zoomSlide() {
-    console.log('you want to zoom');
+    //console.log('you want to zoom');
     this.setState({
       zoomed: !this.state.zoomed
     });

--- a/client/src/Components/ProductOverview/POComponents/ImageGallery.jsx
+++ b/client/src/Components/ProductOverview/POComponents/ImageGallery.jsx
@@ -75,7 +75,7 @@ class ImageGallery extends React.Component {
           <div className='image-thumbnails' >
           </div>
           <div className='carousel'>
-            {this.state.current !== 0 && (<button className='carousel__button carousel__button--left' onClick={this.prevSlide} >
+            {(this.state.current !== 0 && !this.state.zoomed) && (<button className='carousel__button carousel__button--left' onClick={this.prevSlide} >
               <i className="fas fa-arrow-left fa-lg"></i>
             </button>
             )}
@@ -90,10 +90,10 @@ class ImageGallery extends React.Component {
                 })}
               </ul>
             </div>
-            <button className='carousel__button carousel__button--expand' onClick={this.expandSlide} >
+            {!this.state.zoomed && <button className='carousel__button carousel__button--expand' onClick={this.expandSlide} >
               <i className="fas fa-expand fa-lg"></i>
-            </button>
-            {this.state.current !== length - 1 && (<button className='carousel__button carousel__button--right' onClick={this.nextSlide} >
+            </button>}
+            {(this.state.current !== length - 1 && !this.state.zoomed) && (<button className='carousel__button carousel__button--right' onClick={this.nextSlide} >
               <i className="fas fa-arrow-right fa-lg"></i>
             </button>)}
           </div>

--- a/client/src/Components/ProductOverview/POComponents/ImageGallery.jsx
+++ b/client/src/Components/ProductOverview/POComponents/ImageGallery.jsx
@@ -29,6 +29,10 @@ class ImageGallery extends React.Component {
 
   expandSlide() {
     console.log('you want to expand the image');
+    this.setState({
+      expanded: !this.state.expanded
+    });
+    this.props.expandSlide();
   }
 
   componentDidUpdate(prevProps) {
@@ -55,9 +59,8 @@ class ImageGallery extends React.Component {
     if (this.state.photos[`${this.props.selectedStyle}_full`]) {
       var length = fullPhotos.length;
       return (
-        <div id='po-image-gallery' >
+        <div className='po-image-gallery' >
           <div className='image-thumbnails' >
-
           </div>
           <div className='carousel'>
             {this.state.current !== 0 && (<button className='carousel__button carousel__button--left' onClick={this.prevSlide} >

--- a/client/src/Components/ProductOverview/POComponents/SingleStyle.jsx
+++ b/client/src/Components/ProductOverview/POComponents/SingleStyle.jsx
@@ -3,8 +3,9 @@ import React from 'react';
 var SingleStyle = ({ selected, onClick, style }) => {
   return (
     <div className='style-element'>
-      <img className={selected ? 'style-img selected' : 'style-img'} src={style.photos[0].thumbnail_url} onClick={onClick}
+      <img className={selected ? 'style-img' : 'style-img'} src={style.photos[0].thumbnail_url} onClick={onClick}
       />
+      {selected && <i className="far fa-check-circle selected"></i>}
     </div>
 
   );

--- a/client/src/Components/ProductOverview/ProductOverview.jsx
+++ b/client/src/Components/ProductOverview/ProductOverview.jsx
@@ -73,14 +73,16 @@ class ProductOverview extends React.Component {
     return (
       <div className='po-main'>
         <div className='po-main-top'>
-          <div className='po-main-left' style={this.state.expanded ? {width: '100%'} : {width: '60%'} }>
+          <div className='po-main-left' style={this.state.expanded ? { width: '100%' } : { width: '60%' }}>
             <ImageGallery styles={this.state.styles} selectedStyle={this.state.style.style_id} expandSlide={this.expandSlide} />
           </div>
           <div className='po-main-right'>
-            <div className='po-reviews'>
-              <AvgRatingStars avgRating={this.props.avgRating} />
-              <button className='btn all-reviews'>Read all reviews</button>
-            </div>
+            {this.props.avgRating ?
+              (<div className='po-reviews'>
+                <AvgRatingStars avgRating={this.props.avgRating} />
+                <button className='btn all-reviews'>Read all reviews</button>
+              </div>)
+              : <br />}
             <h3>{this.state.category}</h3>
             <h1>{this.state.name}</h1>
             <Price price={this.state.price} sale={this.state.sale} salePrice={this.state.salePrice} />
@@ -88,7 +90,7 @@ class ProductOverview extends React.Component {
             <AddToCart style={this.state.style} />
           </div>
         </div>
-        <br/> <br/>
+        <br /> <br />
         <div className='po-desc'>
           <div className='po-desc-text'>
             <p><b>{this.state.slogan}</b></p>

--- a/client/src/Components/ProductOverview/ProductOverview.jsx
+++ b/client/src/Components/ProductOverview/ProductOverview.jsx
@@ -15,11 +15,13 @@ class ProductOverview extends React.Component {
       id: this.props.productId,
       features: [],
       styles: [],
-      style: {}
+      style: {},
+      expanded: false
     };
     this.getProductInfo = this.getProductInfo.bind(this);
     this.getStyleInfo = this.getStyleInfo.bind(this);
     this.setStyleSelection = this.setStyleSelection.bind(this);
+    this.expandSlide = this.expandSlide.bind(this);
   }
 
   getProductInfo(id) {
@@ -61,12 +63,18 @@ class ProductOverview extends React.Component {
     }
   }
 
+  expandSlide() {
+    this.setState({
+      expanded: !this.state.expanded
+    });
+  }
+
   render() {
     return (
       <div className='po-main'>
         <div className='po-main-top'>
-          <div className='po-main-left'>
-            <ImageGallery styles={this.state.styles} selectedStyle={this.state.style.style_id} />
+          <div className='po-main-left' style={this.state.expanded ? {width: '100%'} : {width: '60%'} }>
+            <ImageGallery styles={this.state.styles} selectedStyle={this.state.style.style_id} expandSlide={this.expandSlide} />
           </div>
           <div className='po-main-right'>
             <div className='po-reviews'>

--- a/client/src/Components/ProductOverview/ProductOverview.jsx
+++ b/client/src/Components/ProductOverview/ProductOverview.jsx
@@ -80,7 +80,7 @@ class ProductOverview extends React.Component {
             {this.props.avgRating ?
               (<div className='po-reviews'>
                 <AvgRatingStars avgRating={this.props.avgRating} />
-                <button className='btn all-reviews'>Read all reviews</button>
+                <a className='read-all-reviews' href='#ratings-and-reviews'>Read all {this.props.totalReviews} reviews</a>
               </div>)
               : <br />}
             <h3>{this.state.category}</h3>

--- a/client/src/app.jsx
+++ b/client/src/app.jsx
@@ -39,6 +39,7 @@ class App extends React.Component {
   render() {
     return (
       <div>
+        <br/>LOGO HERE<br/>Sale Link Here<br/>
         <ProductOverview productId={this.state.product_id} avgRating={this.state.avgRating} />
         <QuestionAnswer productId={this.state.product_id} productName={this.state.product_name} />
         <RelatedProductsView productId={this.state.product_id} />

--- a/client/src/app.jsx
+++ b/client/src/app.jsx
@@ -17,7 +17,8 @@ class App extends React.Component {
     this.state = {
       'product_id': '40344',
       'product_name': 'Camo Onesie',
-      avgRating: null
+      avgRating: null,
+      totalReviews: null
     };
   }
 
@@ -31,20 +32,24 @@ class App extends React.Component {
       method: 'GET'
     })
       .then((results) => results.data.ratings)
-      .then((ratingsObj) => helpers.determineAverageRating(ratingsObj))
-      .then((avgRating) => this.setState({avgRating: avgRating}))
+      .then((ratingsObj) => {
+        this.setState({
+          totalReviews: helpers.determineTotalReviews(ratingsObj),
+          avgRating: helpers.determineAverageRating(ratingsObj)
+        });
+      })
       .catch((error) => console.log(error));
   }
 
   render() {
     return (
       <div>
-        <br/>LOGO HERE<br/>Sale Link Here<br/>
-        <ProductOverview productId={this.state.product_id} avgRating={this.state.avgRating} />
+        <br />LOGO HERE<br />Sale Link Here<br />
+        <ProductOverview productId={this.state.product_id} avgRating={this.state.avgRating} totalReviews={this.state.totalReviews} />
         <QuestionAnswer productId={this.state.product_id} productName={this.state.product_name} />
         <RelatedProductsView productId={this.state.product_id} />
-        <YourOutfitList productId={this.state.product_id}/>
-        <RatingsAndReviews product_id={this.state.product_id} product_name={this.state.product_name}/>
+        <YourOutfitList productId={this.state.product_id} />
+        <RatingsAndReviews product_id={this.state.product_id} product_name={this.state.product_name} />
       </div>
     );
   }


### PR DESCRIPTION
From ticket: https://trello.com/c/8StDPHYj
- If the user clicks on the image, the image gallery should change to the expanded view.

From ticket: https://trello.com/c/rBvFMMOy
- The expanded view will also primarily consist of a main image.  Unlike the default view, this main image will span the entire screen.
- The main image will still offer right and left arrows, which will have the same function of scrolling through the image set.
- Instead of displaying a magnifying glass on hover, in the expanded view the mouse should become a “+” symbol while hovering over the main image.

Misc:
Fixed up total ratings, style selector having a checkmark on current style, css stylings
