### PR TITLE
QA - Fixed bug on image pop out

### DIFF
--- a/client/src/Components/QuestionAnswer/AnswerPhotoList.jsx
+++ b/client/src/Components/QuestionAnswer/AnswerPhotoList.jsx
@@ -3,13 +3,21 @@ import AddAnswerModal from './AddAnswerModal.jsx';
 
 var AnswerPhotoList = (props) => {
   const modalRef = React.useRef();
+  const [selectedPhoto, setSelectedPhoto] = useState(null);
+
+  var handleImageClicked = (e) => {
+    return (
+      modalRef.current.open(),
+      setSelectedPhoto(e.target.currentSrc)
+    );
+  };
 
   var image = props.photos.map(photo => {
     return (
       <React.Fragment key={photo.id}>
-        <img className="qa-photos-minus" src={photo.url} onClick={() => modalRef.current.open()}></img>
+        <img className="qa-photos-minus" src={photo.url} onClick={handleImageClicked}></img>
         <AddAnswerModal ref={modalRef}>
-          <img className="qa-photos-plus" src={photo.url}></img>
+          <img className="qa-photos-plus" src={selectedPhoto}></img>
           <i class="fas fa-times fa-3x qa-photos-icon" onClick={() => modalRef.current.close()}></i>
         </AddAnswerModal>
       </React.Fragment>


### PR DESCRIPTION
1. Fixed bug on image pop-out: Originally, when clicked on an image in answer list, it will pop out the last image even though if clicking on the first image. This bug is fixed to show the correct image popping out.

https://trello.com/c/HQJmL0iV

@vannguyen-vn @thecaitlinkinney @isabell-lee Please review.